### PR TITLE
Add IDE selector for file links in HTML reports to Development

### DIFF
--- a/dist/bin/json-to-html.py
+++ b/dist/bin/json-to-html.py
@@ -170,13 +170,13 @@ def main():
     
     # Create clickable links for scanned paths
     abs_path = os.path.abspath(paths) if not os.path.isabs(paths) else paths
-    paths_link = f'<a href="file://{abs_path}" style="color: #667eea;">{paths}</a>'
+    paths_link = f'<a href="file://{abs_path}" class="ide-link" data-file="{abs_path}" style="color: #667eea;">{paths}</a>'
 
     # Create clickable link for JSON log file
     json_log_link = ""
     if os.path.isfile(input_json):
         abs_json_path = os.path.abspath(input_json)
-        log_link = f'<a href="file://{abs_json_path}" style="color: #667eea;">{input_json}</a>'
+        log_link = f'<a href="file://{abs_json_path}" class="ide-link" data-file="{abs_json_path}" style="color: #667eea;">{input_json}</a>'
         json_log_link = f'<div style="margin-top: 8px;">JSON Log: {log_link} <button class="copy-btn" onclick="copyLogPath()" title="Copy JSON log path to clipboard">📋 Copy Path</button></div>'
 
     # Determine status
@@ -217,7 +217,7 @@ def main():
         <span class="badge {impact}">{impact.upper()}</span>
       </div>
       <div class="finding-details">
-        <div class="file-path"><a href="file://{abs_file}" style="color: #667eea; text-decoration: none;" title="Click to open file">{file_path}</a>:{line}</div>
+        <div class="file-path"><a href="file://{abs_file}" class="ide-link" data-file="{abs_file}" data-line="{line}" style="color: #667eea; text-decoration: none;" title="Click to open in IDE">{file_path}</a>:{line}</div>
         <div class="code-snippet">{code_escaped}</div>
       </div>
     </div>'''

--- a/dist/bin/templates/report-template.html
+++ b/dist/bin/templates/report-template.html
@@ -273,6 +273,57 @@
       border-bottom: 1px solid #dee2e6;
     }
 
+    /* IDE Selector Styles */
+    .ide-selector {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 20px;
+      flex-wrap: wrap;
+    }
+
+    .ide-selector-label {
+      font-size: 0.9em;
+      color: #495057;
+      font-weight: 500;
+    }
+
+    .ide-buttons {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .ide-btn {
+      padding: 4px 12px;
+      border: 1px solid #dee2e6;
+      border-radius: 4px;
+      background: white;
+      color: #495057;
+      font-size: 0.8em;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .ide-btn:hover {
+      border-color: #667eea;
+      background: #f0f4ff;
+    }
+
+    .ide-btn.active {
+      border-color: #667eea;
+      background: #667eea;
+      color: white;
+    }
+
+    .ide-btn .ide-icon {
+      font-size: 1.1em;
+    }
+
     .search-input-wrapper {
       position: relative;
       width: 100%;
@@ -564,6 +615,16 @@
       <!-- Findings Section -->
       <div class="section">
         <h2>📋 Findings ({{FINDINGS_COUNT}})</h2>
+        <!-- IDE Selector -->
+        <div class="ide-selector">
+          <span class="ide-selector-label">Open in:</span>
+          <div class="ide-buttons">
+            <button class="ide-btn" data-ide="vscode" title="Open in VS Code">💻 VS Code</button>
+            <button class="ide-btn" data-ide="cursor" title="Open in Cursor">⚡ Cursor</button>
+            <button class="ide-btn" data-ide="augment" title="Open in Augment">🔮 Augment</button>
+            <button class="ide-btn" data-ide="file" title="Use file:// protocol">📁 File</button>
+          </div>
+        </div>
         {{FINDINGS_HTML}}
       </div>
 
@@ -630,8 +691,60 @@
       });
     }
 
+    // IDE Protocol Configuration
+    const ideProtocols = {
+      vscode: { prefix: 'vscode://file', format: (file, line) => line ? `vscode://file${file}:${line}` : `vscode://file${file}` },
+      cursor: { prefix: 'cursor://file', format: (file, line) => line ? `cursor://file${file}:${line}` : `cursor://file${file}` },
+      augment: { prefix: 'augment://file', format: (file, line) => line ? `augment://file${file}:${line}` : `augment://file${file}` },
+      file: { prefix: 'file://', format: (file, line) => `file://${file}` }
+    };
+
+    // IDE Selector functionality
+    function initIdeSelector() {
+      const ideButtons = document.querySelectorAll('.ide-btn');
+      const ideLinks = document.querySelectorAll('.ide-link');
+
+      // Load saved preference or default to 'file'
+      const savedIde = localStorage.getItem('wp-code-check-ide') || 'file';
+
+      // Set initial active state and update links
+      updateIdeSelection(savedIde, ideButtons, ideLinks);
+
+      // Add click handlers to IDE buttons
+      ideButtons.forEach(btn => {
+        btn.addEventListener('click', function() {
+          const ide = this.dataset.ide;
+          localStorage.setItem('wp-code-check-ide', ide);
+          updateIdeSelection(ide, ideButtons, ideLinks);
+        });
+      });
+    }
+
+    function updateIdeSelection(ide, buttons, links) {
+      // Update button states
+      buttons.forEach(btn => {
+        if (btn.dataset.ide === ide) {
+          btn.classList.add('active');
+        } else {
+          btn.classList.remove('active');
+        }
+      });
+
+      // Update all links
+      const protocol = ideProtocols[ide] || ideProtocols.file;
+      links.forEach(link => {
+        const file = link.dataset.file;
+        const line = link.dataset.line;
+        if (file) {
+          link.href = protocol.format(file, line);
+        }
+      });
+    }
+
     // Convert UTC timestamp to local time
     document.addEventListener('DOMContentLoaded', function() {
+      // Initialize IDE selector
+      initIdeSelector();
       // Get the UTC timestamp from the page
       const utcTimestamp = '{{TIMESTAMP}}';
 


### PR DESCRIPTION
## Summary
- Adds IDE selector UI with buttons for VS Code, Cursor, Augment, and File protocols
- Positions selector just above Findings section for clear association with file links
- Stores user preference in localStorage for persistence across reports
- Clicking a file link opens directly in the selected IDE at the correct line number

## Test plan
- [ ] Generate an HTML report with `json-to-html.py`
- [ ] Verify IDE selector appears above Findings section
- [ ] Click each IDE button and verify links update (inspect href)
- [ ] Click a file link with VS Code/Cursor selected to verify it opens in IDE
- [ ] Refresh page and verify preference is remembered

Closes #65

🤖 Generated with [Claude Code](https://claude.ai/code)